### PR TITLE
Sad paths

### DIFF
--- a/app/controllers/api/v1/backgrounds_controller.rb
+++ b/app/controllers/api/v1/backgrounds_controller.rb
@@ -1,11 +1,15 @@
 class Api::V1::BackgroundsController < ApplicationController
   def index
-    location_data = MapService.new.location(params[:location])
-    location = Location.new(location_data)
-    forecast_data = WeatherService.new.forecast(location.latitude, location.longitude)
-    forecast = Forecast.new(forecast_data)
-    image_data = ImageService.new.background(forecast.current[:weather][0][:description])
-    render json: BackgroundSerializer.new(Background.new(image_data[:results][0]))
+    if params[:location].present?
+      location_data = MapService.new.location(params[:location])
+      location = Location.new(location_data)
+      forecast_data = WeatherService.new.forecast(location.latitude, location.longitude)
+      forecast = Forecast.new(forecast_data)
+      image_data = ImageService.new.background(forecast.current[:weather][0][:description])
+      render json: BackgroundSerializer.new(Background.new(image_data[:results][0]))
+    else
+      render json: {errors: ['Location is required.']}, status: :bad_request
+    end
   end
 
 end

--- a/app/controllers/api/v1/forecasts_controller.rb
+++ b/app/controllers/api/v1/forecasts_controller.rb
@@ -1,7 +1,11 @@
 class Api::V1::ForecastsController < ApplicationController
   def show
-    forecast = ForecastFacade.new(forecast_params[:location])
-    render json: ForecastSerializer.new(forecast)
+    if params[:location].present?
+      forecast = ForecastFacade.new(forecast_params[:location])
+      render json: ForecastSerializer.new(forecast)
+    else
+      render json: {errors: ['Location is required.']}, status: :bad_request
+    end
   end
 
   private

--- a/app/controllers/api/v1/road_trip_controller.rb
+++ b/app/controllers/api/v1/road_trip_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::RoadTripController < ApplicationController
         begin
         road_trip = RoadTripFacade.new(road_trip_params[:origin], road_trip_params[:destination])
         rescue NoMethodError
-          return render json: {errors: ["Looks like there was a problem finding these locations."]}, status: :bad_request 
+          return render json: {errors: ["Looks like we were unable to find these locations."]}, status: :not_found
         end
         render json: RoadTripSerializer.new(road_trip)
       else render json: {errors: ['Origin and destination are required']}, status: :bad_request 

--- a/app/controllers/api/v1/road_trip_controller.rb
+++ b/app/controllers/api/v1/road_trip_controller.rb
@@ -3,7 +3,11 @@ class Api::V1::RoadTripController < ApplicationController
     user = User.find_by(api_key: road_trip_params[:api_key])
     if user
       if road_trip_params[:destination].present? && road_trip_params[:origin].present?
+        begin
         road_trip = RoadTripFacade.new(road_trip_params[:origin], road_trip_params[:destination])
+        rescue NoMethodError
+          return render json: {errors: ["Looks like there was a problem finding these locations."]}, status: :bad_request 
+        end
         render json: RoadTripSerializer.new(road_trip)
       else render json: {errors: ['Origin and destination are required']}, status: :bad_request 
       end

--- a/spec/fixtures/vcr_cassettes/Api_V1_RoadTrips/post_road_trip/returns_an_error_if_it_can_t_find_results.yml
+++ b/spec/fixtures/vcr_cassettes/Api_V1_RoadTrips/post_road_trip/returns_an_error_if_it_can_t_find_results.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://www.mapquestapi.com/directions/v2/route?from=Denver,%20CO&key=<mapquest_api_key>&to=ajfba
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Aug 2020 02:19:17 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '278'
+      Server:
+      - Apache-Coyote/1.1
+      Set-Cookie:
+      - JSESSIONID=FB79650F1937993500FD71E7FDB82736; Path=/directions; HttpOnly
+      Expires:
+      - Mon, 20 Dec 1998 01:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Aug 2020 02:19:17 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Pragma:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - OPTIONS,GET,POST
+      Status:
+      - success
+      Transactionweight:
+      - '1'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJyb3V0ZSI6eyJyb3V0ZUVycm9yIjp7ImVycm9yQ29kZSI6MiwibWVzc2FnZSI6IiJ9fSwiaW5mbyI6eyJzdGF0dXNjb2RlIjo0MDIsImNvcHlyaWdodCI6eyJpbWFnZUFsdFRleHQiOiLCqSAyMDIwIE1hcFF1ZXN0LCBJbmMuIiwiaW1hZ2VVcmwiOiJodHRwOi8vYXBpLm1xY2RuLmNvbS9yZXMvbXFsb2dvLmdpZiIsInRleHQiOiLCqSAyMDIwIE1hcFF1ZXN0LCBJbmMuIn0sIm1lc3NhZ2VzIjpbIldlIGFyZSB1bmFibGUgdG8gcm91dGUgd2l0aCB0aGUgZ2l2ZW4gbG9jYXRpb25zLiJdfX0=
+  recorded_at: Wed, 05 Aug 2020 02:19:17 GMT
+recorded_with: VCR 6.0.0

--- a/spec/requests/api/v1/backgrounds_request_spec.rb
+++ b/spec/requests/api/v1/backgrounds_request_spec.rb
@@ -11,6 +11,15 @@ RSpec.describe "Api::V1::Backgrounds", type: :request do
       expect(background[:data][:attributes][:id]).to_not be_nil
       expect(background[:data][:attributes][:url]).to_not be_nil
     end
-  end
 
+    it "returns errors when no location param is submitted" do
+      request_params = {}
+      get '/api/v1/backgrounds', params: request_params
+      expect(response).to have_http_status(:bad_request)
+      errors = JSON.parse(response.body, symbolize_names: true)
+
+      expect(errors[:errors].length).to eq(1)
+      expect(errors[:errors].first).to eq('Location is required.')
+    end
+  end
 end

--- a/spec/requests/api/v1/forecasts_request_spec.rb
+++ b/spec/requests/api/v1/forecasts_request_spec.rb
@@ -34,5 +34,15 @@ RSpec.describe "Api::V1::Forecasts", type: :request do
         expect(day[:precipitation]).to_not be_nil
       end
     end
+
+    it "returns errors when no location param is submitted" do
+      request_params = {}
+      get '/api/v1/forecast', params: request_params
+      expect(response).to have_http_status(:bad_request)
+      errors = JSON.parse(response.body, symbolize_names: true)
+
+      expect(errors[:errors].length).to eq(1)
+      expect(errors[:errors].first).to eq('Location is required.')
+    end
   end
 end

--- a/spec/requests/api/v1/road_trip_request_spec.rb
+++ b/spec/requests/api/v1/road_trip_request_spec.rb
@@ -87,12 +87,12 @@ RSpec.describe "Api::V1::RoadTrips", type: :request do
               }
 
       post "/api/v1/road_trip", params: request_params.to_json, headers: { "Content-Type": "application/json" }
-      expect(response).to have_http_status(:bad_request)
+      expect(response).to have_http_status(:not_found)
 
       errors = JSON.parse(response.body, symbolize_names: true)
       
       expect(errors[:errors].length).to eq(1)
-      expect(errors[:errors].first).to eq('Looks like there was a problem finding these locations.')
+      expect(errors[:errors].first).to eq('Looks like we were unable to find these locations.')
     end
   end
 end

--- a/spec/requests/api/v1/road_trip_request_spec.rb
+++ b/spec/requests/api/v1/road_trip_request_spec.rb
@@ -79,7 +79,20 @@ RSpec.describe "Api::V1::RoadTrips", type: :request do
       expect(errors[:errors].first).to eq('Origin and destination are required')
     end
 
-    
-  end
+    it "returns an error if it can't find results", :vcr do
+      request_params = { 
+              origin: "Denver, CO",
+              destination: "ajfba",
+              api_key: @user.api_key
+              }
 
+      post "/api/v1/road_trip", params: request_params.to_json, headers: { "Content-Type": "application/json" }
+      expect(response).to have_http_status(:bad_request)
+
+      errors = JSON.parse(response.body, symbolize_names: true)
+      
+      expect(errors[:errors].length).to eq(1)
+      expect(errors[:errors].first).to eq('Looks like there was a problem finding these locations.')
+    end
+  end
 end


### PR DESCRIPTION
Adds additional sad paths for various scenarios and tests for these sad paths.

RSpec results:
```Finished in 0.50038 seconds (files took 2.58 seconds to load)
22 examples, 0 failures

Coverage report generated for RSpec to /Users/kyleiverson/turing/3module/sweater_weather/coverage. 411 / 411 LOC (100.0%) covered.```